### PR TITLE
Clike params and instantiation from_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ lt_entries = value #(
 lo_map->from_entries( lt_entries ).
 ```
 
-- implements `from_string` - this parses string of pairs like `a = b, x = y` into map. Spaces are condensed.
+- implements `from_string` - this parses string of pairs like `a = b, x = y` into map. Spaces are condensed. `to_string` renders in string representation (careful with case insensitive - keys will be upper-cased).
 
 ```abap
 lo_map->from_string( 'a = b, x = y' ).
 lo_map->get( 'a' ). " => 'b'
+lo_map->to_string( ). " => 'a=b,x=y'
 ```
 
 - may set the map immutable (read only). Guards `set`, `delete`, `clear`, `from_*` methods.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ String map primitive implementation for abap
 - install using [abapGit](https://github.com/larshp/abapGit)
 - errors, if happen, are raised via `cx_no_check` (with get_text)
 - implements `get`, `set`, `has`, `size`, `is_empty`, `delete`
+- also convenience features to create map from string, table or structure (key/value)
 
 ```abap
 data lo_map type ref to zcl_abap_string_map.
 lo_map = zcl_abap_string_map=>create( ). " or create object ...
 
+" Key and value can be a string or of C or N types (so `clike`)
 lo_map->set(
   iv_key = 'hello'
   iv_val = 'world' ).
@@ -30,7 +32,8 @@ lo_map->clear( ).
 ```abap
 lo_map->set(
   iv_key = 'A'
-  iv_val = '1' )->set(
+  iv_val = '1' 
+)->set(
   iv_key = 'B'
   iv_val = '2' ).
 ```
@@ -80,6 +83,13 @@ lt_entries = value #(
 lo_map->from_entries( lt_entries ).
 ```
 
+- implements `from_string` - this parses string of pairs like `a = b, x = y` into map. Spaces are condensed.
+
+```abap
+lo_map->from_string( 'a = b, x = y' ).
+lo_map->get( 'a' ). " => 'b'
+```
+
 - may set the map immutable (read only). Guards `set`, `delete`, `clear`, `from_*` methods.
 
 ```abap
@@ -98,6 +108,7 @@ lo_map->set(
 lo_copy = zcl_abap_string_map=>create( lo_map ).
 lo_copy = zcl_abap_string_map=>create( ls_struc ).   " see examples above
 lo_copy = zcl_abap_string_map=>create( lt_entries ). " see examples above
+lo_copy = zcl_abap_string_map=>create( 'a=b, x=y' ). " see examples above
 ```
 
 For more examples see [unit tests code](https://github.com/sbcgua/abap-string-map/blob/master/src/zcl_abap_string_map.clas.testclasses.abap)

--- a/src/zcl_abap_string_map.clas.abap
+++ b/src/zcl_abap_string_map.clas.abap
@@ -9,9 +9,9 @@ class zcl_abap_string_map definition
 
     types:
       begin of ty_entry,
-          k type string,
-          v type string,
-        end of ty_entry .
+        k type string,
+        v type string,
+      end of ty_entry .
     types:
       tty_entries type standard table of ty_entry with key k .
     types:

--- a/src/zcl_abap_string_map.clas.abap
+++ b/src/zcl_abap_string_map.clas.abap
@@ -32,18 +32,18 @@ class zcl_abap_string_map definition
 
     methods get
       importing
-        !iv_key type string
+        !iv_key type clike
       returning
         value(rv_val) type string .
     methods has
       importing
-        !iv_key type string
+        !iv_key type clike
       returning
         value(rv_has) type abap_bool .
     methods set
       importing
-        !iv_key type string
-        !iv_val type string
+        !iv_key type clike
+        !iv_val type clike
       returning
         value(ro_map) type ref to zcl_abap_string_map.
     methods size
@@ -54,7 +54,7 @@ class zcl_abap_string_map definition
         value(rv_yes) type abap_bool .
     methods delete
       importing
-        !iv_key type string .
+        !iv_key type clike .
     methods keys
       returning
         value(rt_keys) type string_table .

--- a/src/zcl_abap_string_map.clas.abap
+++ b/src/zcl_abap_string_map.clas.abap
@@ -74,6 +74,9 @@ class zcl_abap_string_map definition
     methods from_string
       importing
         !iv_string_params type csequence.
+    methods to_string
+      returning
+        value(rv_string) type string.
     methods strict
       importing
         !iv_strict type abap_bool default abap_true
@@ -340,6 +343,22 @@ CLASS ZCL_ABAP_STRING_MAP IMPLEMENTATION.
   method strict.
     mv_is_strict = iv_strict.
     ro_instance = me.
+  endmethod.
+
+
+  method to_string.
+
+    data lv_size type i.
+    field-symbols <entry> like line of mt_entries.
+
+    lv_size = lines( mt_entries ).
+    loop at mt_entries assigning <entry>.
+      rv_string = rv_string && <entry>-k && '=' && <entry>-v.
+      if sy-tabix < lv_size.
+        rv_string = rv_string && ','.
+      endif.
+    endloop.
+
   endmethod.
 
 

--- a/src/zcl_abap_string_map.clas.abap
+++ b/src/zcl_abap_string_map.clas.abap
@@ -71,6 +71,9 @@ class zcl_abap_string_map definition
     methods from_entries
       importing
         !it_entries type any table.
+    methods from_string
+      importing
+        !iv_string_params type csequence.
     methods strict
       importing
         !iv_strict type abap_bool default abap_true
@@ -125,6 +128,9 @@ CLASS ZCL_ABAP_STRING_MAP IMPLEMENTATION.
         when cl_abap_typedescr=>typekind_table.
           me->from_entries( iv_from ).
 
+        when cl_abap_typedescr=>typekind_string or cl_abap_typedescr=>typekind_char.
+          me->from_string( iv_from ).
+
         when others.
           lcx_error=>raise( |Incorrect input for string_map=>create, typekind { lo_type->type_kind }| ).
       endcase.
@@ -177,6 +183,33 @@ CLASS ZCL_ABAP_STRING_MAP IMPLEMENTATION.
       set(
         iv_key = <i>-k
         iv_val = <i>-v ).
+    endloop.
+
+  endmethod.
+
+
+  method from_string.
+
+    if iv_string_params is initial.
+      return.
+    endif.
+
+    data lt_lines type string_table.
+    field-symbols <i> like line of lt_lines.
+    split iv_string_params at ',' into table lt_lines.
+
+    data lv_key type string.
+    data lv_val type string.
+    loop at lt_lines assigning <i>.
+      split <i> at '=' into lv_key lv_val.
+      condense: lv_key, lv_val.
+      if lv_key is initial.
+        lcx_error=>raise( 'Empty key in initialization string is not allowed' ).
+        " value can be initial, even a,b,c is ok to create sets
+      endif.
+      set(
+        iv_key = lv_key
+        iv_val = lv_val ).
     endloop.
 
   endmethod.

--- a/src/zcl_abap_string_map.clas.abap
+++ b/src/zcl_abap_string_map.clas.abap
@@ -202,7 +202,10 @@ CLASS ZCL_ABAP_STRING_MAP IMPLEMENTATION.
     data lv_val type string.
     loop at lt_lines assigning <i>.
       split <i> at '=' into lv_key lv_val.
-      condense: lv_key, lv_val.
+      shift lv_key right deleting trailing space.
+      shift lv_key left deleting leading space.
+      shift lv_val right deleting trailing space.
+      shift lv_val left deleting leading space.
       if lv_key is initial.
         lcx_error=>raise( 'Empty key in initialization string is not allowed' ).
         " value can be initial, even a,b,c is ok to create sets

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -25,6 +25,7 @@ class ltcl_string_map definition
     methods freeze for testing.
     methods create_from for testing.
     methods case_insensitive for testing.
+    methods set_clike for testing.
 
 endclass.
 
@@ -535,6 +536,42 @@ class ltcl_string_map implementation.
     cl_abap_unit_assert=>assert_equals(
       exp = 0
       act = lo_cut->size( ) ).
+
+  endmethod.
+
+  method set_clike.
+
+    data lo_cut type ref to zcl_abap_string_map.
+    lo_cut = zcl_abap_string_map=>create( ).
+
+    lo_cut->set(
+      iv_key = 'A'
+      iv_val = 'avalue' ).
+    lo_cut->set(
+      iv_key = `B`
+      iv_val = `bvalue` ).
+
+    data lv_char type c length 10.
+    lv_char = 'C'.
+    lo_cut->set(
+      iv_key = lv_char
+      iv_val = lv_char ).
+
+    data lv_numc type n length 4.
+    lv_numc = '123'.
+    lo_cut->set(
+      iv_key = lv_numc
+      iv_val = lv_numc ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 4
+      act = lo_cut->size( ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = 'C'
+      act = lo_cut->get( 'C' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = '0123'
+      act = lo_cut->get( '0123' ) ).
 
   endmethod.
 

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -590,17 +590,20 @@ class ltcl_string_map implementation.
     data lo_cut type ref to zcl_abap_string_map.
     lo_cut = zcl_abap_string_map=>create( ).
 
-    lo_cut->from_string( 'a = avalue, b = some data' ).
+    lo_cut->from_string( 'a = avalue, b = some data, c = space   space' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lo_cut->size( )
-      exp = 2 ).
+      exp = 3 ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_cut->get( 'a' )
       exp = 'avalue' ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_cut->get( 'b' )
       exp = 'some data' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->get( 'c' )
+      exp = 'space   space' ).
 
     data lx type ref to lcx_error.
     try.

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -27,6 +27,7 @@ class ltcl_string_map definition
     methods case_insensitive for testing.
     methods set_clike for testing.
     methods from_string for testing.
+    methods to_string for testing.
 
 endclass.
 
@@ -621,6 +622,18 @@ class ltcl_string_map implementation.
     cl_abap_unit_assert=>assert_equals(
       act = lo_cut->get( 'x' )
       exp = 'y' ).
+
+  endmethod.
+
+  method to_string.
+
+    data lo_cut type ref to zcl_abap_string_map.
+    lo_cut = zcl_abap_string_map=>create( ).
+
+    lo_cut->from_string( 'a = avalue, b = some data, c = space   space' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->to_string( )
+      exp = 'a=avalue,b=some data,c=space   space' ).
 
   endmethod.
 

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -161,6 +161,15 @@ class ltcl_string_map implementation.
         act = lx->get_text( ) ).
     endtry.
 
+    try.
+      lo_cut->from_string( 'x=y' ).
+      cl_abap_unit_assert=>fail( ).
+    catch cx_root into lx.
+      cl_abap_unit_assert=>assert_equals(
+        exp = 'String map is read only'
+        act = lx->get_text( ) ).
+    endtry.
+
   endmethod.
 
   method get_set_has.

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -26,6 +26,7 @@ class ltcl_string_map definition
     methods create_from for testing.
     methods case_insensitive for testing.
     methods set_clike for testing.
+    methods from_string for testing.
 
 endclass.
 
@@ -43,11 +44,11 @@ class ltcl_string_map implementation.
       iv_val = '1' ).
 
     try.
-      zcl_abap_string_map=>create( iv_from = `abc` ).
+      zcl_abap_string_map=>create( iv_from = 12345 ).
       cl_abap_unit_assert=>fail( ).
     catch cx_root into lx.
       cl_abap_unit_assert=>assert_equals(
-        exp = 'Incorrect input for string_map=>create, typekind g'
+        exp = 'Incorrect input for string_map=>create, typekind I'
         act = lx->get_text( ) ).
     endtry.
 
@@ -572,6 +573,42 @@ class ltcl_string_map implementation.
     cl_abap_unit_assert=>assert_equals(
       exp = '0123'
       act = lo_cut->get( '0123' ) ).
+
+  endmethod.
+
+  method from_string.
+
+    data lo_cut type ref to zcl_abap_string_map.
+    lo_cut = zcl_abap_string_map=>create( ).
+
+    lo_cut->from_string( 'a = avalue, b = some data' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->size( )
+      exp = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->get( 'a' )
+      exp = 'avalue' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->get( 'b' )
+      exp = 'some data' ).
+
+    data lx type ref to lcx_error.
+    try.
+      lo_cut->from_string( `x=y,  ` ).
+    catch lcx_error into lx.
+      cl_abap_unit_assert=>assert_char_cp(
+        act = lx->get_text( )
+        exp = 'Empty key*' ).
+    endtry.
+
+    lo_cut = zcl_abap_string_map=>create( iv_from = 'x=y' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->size( )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->get( 'x' )
+      exp = 'y' ).
 
   endmethod.
 


### PR DESCRIPTION
- key/value are `clike` now, no need to force convert to string (careful with `numc` - they get leading zeroes)
- from_string( 'a = b, x = y' ) construction/addition
- to_string( ) - serialization into key=value pairs

@mbtools: FYI new features