### PR TITLE
Fix compatibility with 7.02

### DIFF
--- a/src/package.devc.xml
+++ b/src/package.devc.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <DEVC>
-    <CTEXT>abap string map</CTEXT>
+    <CTEXT>ABAP String Map</CTEXT>
    </DEVC>
   </asx:values>
  </asx:abap>

--- a/src/zcl_abap_string_map.clas.testclasses.abap
+++ b/src/zcl_abap_string_map.clas.testclasses.abap
@@ -579,11 +579,21 @@ class ltcl_string_map implementation.
       exp = 'bvalue'
       act = lo_cut->get( 'b' ) ).
 
-    cl_abap_unit_assert=>assert_true( lo_cut->has( 'A' ) ).
-    cl_abap_unit_assert=>assert_true( lo_cut->has( 'a' ) ).
-    cl_abap_unit_assert=>assert_true( lo_cut->has( 'B' ) ).
-    cl_abap_unit_assert=>assert_true( lo_cut->has( 'b' ) ).
-    cl_abap_unit_assert=>assert_false( lo_cut->has( 'c' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = lo_cut->has( 'A' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = lo_cut->has( 'a' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = lo_cut->has( 'B' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_true
+      act = lo_cut->has( 'b' ) ).
+    cl_abap_unit_assert=>assert_equals(
+      exp = abap_false
+      act = lo_cut->has( 'c' ) ).
 
     append 'A' to lt_exp_keys.
     append 'B' to lt_exp_keys.


### PR DESCRIPTION
`assert_true/false` does not exist in lower releases